### PR TITLE
[#54] main page toggle

### DIFF
--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,14 +1,30 @@
+import DeleteIcon from "@mui/icons-material/Delete";
+import { useState } from "react";
 import Nav from "src/components/Nav";
 import BottomNav from "src/components/Nav/BottomNav";
 import Timeline from "src/components/Timeline";
 import styled from "styled-components";
 
 function Main() {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  function toggle() {
+    setIsOpen((isOpen) => !isOpen);
+  }
+
   return (
     <>
       <Nav />
+      <StyledBtn
+        onClick={() => {
+          setIsOpen((e) => !e);
+        }}
+      >
+        <DeleteIcon />
+        <StyledTrashText>Trash</StyledTrashText>
+      </StyledBtn>
       <StyledWrapper>
-        <Timeline />
+        <div onClick={() => toggle()}>{isOpen && <Timeline />}</div>
       </StyledWrapper>
       <BottomNav selected="Home" />
     </>
@@ -21,4 +37,21 @@ const StyledWrapper = styled.div`
   position: relative;
   width: 100%;
   padding: 1rem 1rem;
+`;
+
+const StyledBtn = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.5rem 0.5rem;
+  color: ${({ theme }) => theme.color.grey100};
+  :hover {
+    transition: all 0.3s;
+    color: #ffffffd2;
+  }
+`;
+
+const StyledTrashText = styled.span`
+  margin-left: 0.1rem;
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
 `;


### PR DESCRIPTION
## Description

- main page 글 리스트를 toggle 형태로 보이게 했어요
- 글 리스트를 toggle에 숨겨놓긴 했지만 사용자가 글 리스트를 `아예 보지 못하게 하는 구성`도 좋을 것 같아요 이 부분 회의 때 다시 얘기해 봐요 !

## Important content

<img src="https://user-images.githubusercontent.com/63100352/221605835-c1e5e540-6049-4c97-8944-f81d898054f7.gif" width="50%" />
